### PR TITLE
fix url for setup-network-environment

### DIFF
--- a/src/settings/user-data
+++ b/src/settings/user-data
@@ -51,7 +51,7 @@ coreos:
         After=network-online.target
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/wget -P /opt/bin hhttps://github.com/kelseyhightower/setup-network-environment/releases/download/1.0.1/setup-network-environment
+        ExecStartPre=/usr/bin/wget -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/1.0.1/setup-network-environment
         ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
         ExecStart=/opt/bin/setup-network-environment
         RemainAfterExit=yes


### PR DESCRIPTION
The URL for the setup-network-environment.service has a typo which
causes the service to fail. Fix the typo "hhttps:" to "https:".